### PR TITLE
Second player

### DIFF
--- a/controllers/time_travel_controller.gd
+++ b/controllers/time_travel_controller.gd
@@ -15,13 +15,13 @@ func start_log_timer():
 
 func _physics_process(delta):
 	# Check if the revert time button is pressed to start the timer.
-	if Input.is_action_just_pressed("ui_up"):
+	if Input.is_action_just_pressed("ui_accept"):
 		# Start the timer and make it repeat.
 		is_reverting = true
 		Global.revert_started.emit()
 		
 	# Check if the revert time button is released to stop the timer.
-	if Input.is_action_just_released("ui_up"):
+	if Input.is_action_just_released("ui_accept"):
 		is_reverting = false
 		Global.revert_stopped.emit()
 

--- a/controllers/time_travel_controller.gd
+++ b/controllers/time_travel_controller.gd
@@ -2,6 +2,11 @@ extends Node
 
 var is_reverting = false
 
+const revert_time_inputs = [
+	"REVERT_P1",
+	"REVERT_P2",
+] 
+
 func _ready():
 	start_log_timer()
 	
@@ -14,16 +19,17 @@ func start_log_timer():
 	add_child(record_timer)
 
 func _physics_process(delta):
-	# Check if the revert time button is pressed to start the timer.
-	if Input.is_action_just_pressed("ui_accept"):
-		# Start the timer and make it repeat.
-		is_reverting = true
-		Global.revert_started.emit()
+	for i in revert_time_inputs.size():
+		var input = revert_time_inputs[i]
+		var player = i +1
 		
-	# Check if the revert time button is released to stop the timer.
-	if Input.is_action_just_released("ui_accept"):
-		is_reverting = false
-		Global.revert_stopped.emit()
+		if Input.is_action_just_pressed(input):
+			is_reverting = true
+			Global.revert_started.emit(player)
+		
+		if Input.is_action_just_released(input):
+			is_reverting = false
+			Global.revert_stopped.emit()
 
 func _on_record_timer_timeout():
 	if is_reverting:

--- a/entities/player/player.gd
+++ b/entities/player/player.gd
@@ -3,6 +3,11 @@ extends CharacterBody2D
 @export var speed = 300.0
 @export var jump_velocity = -450.0
 
+## Input map
+@export var left_action: String = "LEFT_P1"
+@export var right_action: String = "RIGHT_P1"
+@export var jump_action: String = "JUMP_P1"
+
 var is_reverting = false
 var _state_history = []
 
@@ -18,10 +23,10 @@ func _physics_process(delta):
 	if not is_on_floor():
 		velocity.y += Global.gravity * delta
 	
-	if is_on_floor() and Input.is_action_just_pressed("ui_accept"): # TODO
+	if is_on_floor() and Input.is_action_just_pressed(jump_action):
 		velocity.y = jump_velocity 
 
-	var direction = Input.get_axis("ui_left", "ui_right") # TODO
+	var direction = Input.get_axis(left_action, right_action) 
 	velocity.x = direction * speed
 
 	move_and_slide()

--- a/entities/player/player.gd
+++ b/entities/player/player.gd
@@ -2,19 +2,26 @@ extends CharacterBody2D
 
 @export var speed = 300.0
 @export var jump_velocity = -450.0
+@export var player_number = 1
 
 ## Input map
-@export var left_action: String = "LEFT_P1"
-@export var right_action: String = "RIGHT_P1"
-@export var jump_action: String = "JUMP_P1"
+var left_action: String
+var right_action: String
+var jump_action: String
+
 
 var is_reverting = false
 var _state_history = []
 
 func _ready():
+	left_action = "LEFT_P%d" % player_number
+	right_action = "RIGHT_P%d" % player_number
+	jump_action = "JUMP_P%d" % player_number
+	
 	Global.revert_started.connect(start_reverting)
 	Global.revert_stopped.connect(stop_reverting)
 	add_to_group(Global.TIME_TRAVEL_GROUP)
+
 
 func _physics_process(delta):
 	if is_reverting:
@@ -42,7 +49,9 @@ func record_state():
 	if _state_history.size() > Global._max_history_length:
 		_state_history.pop_back()
 		
-func start_reverting():
+func start_reverting(player):
+	if player == player_number:
+		return
 	is_reverting = true
 
 func stop_reverting():

--- a/global.gd
+++ b/global.gd
@@ -9,5 +9,5 @@ const _max_history_length = (10 /  log_delay) * 1.2
 const TIME_TRAVEL_GROUP = "time_travelable"
 
 ## Signals
-signal revert_started()
+signal revert_started(player: int)
 signal revert_stopped()

--- a/levels/level.tscn
+++ b/levels/level.tscn
@@ -31,6 +31,4 @@ script = ExtResource("3_cwqvt")
 
 [node name="Player2" parent="." instance=ExtResource("1_80vhd")]
 position = Vector2(420, 186)
-left_action = "LEFT_P2"
-right_action = "RIGHT_P2"
-jump_action = "JUMP_P2"
+player_number = 2

--- a/levels/level.tscn
+++ b/levels/level.tscn
@@ -6,7 +6,7 @@
 
 [node name="Node2D" type="Node2D"]
 
-[node name="Player" parent="." instance=ExtResource("1_80vhd")]
+[node name="Player1" parent="." instance=ExtResource("1_80vhd")]
 position = Vector2(220, 187)
 
 [node name="Platforms" type="Node" parent="."]
@@ -28,3 +28,9 @@ position = Vector2(409, 383)
 
 [node name="TimeTravelController" type="Node" parent="."]
 script = ExtResource("3_cwqvt")
+
+[node name="Player2" parent="." instance=ExtResource("1_80vhd")]
+position = Vector2(420, 186)
+left_action = "LEFT_P2"
+right_action = "RIGHT_P2"
+jump_action = "JUMP_P2"

--- a/project.godot
+++ b/project.godot
@@ -18,3 +18,36 @@ config/icon="res://icon.svg"
 [autoload]
 
 Global="*res://global.gd"
+
+[input]
+
+JUMP_P1={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
+]
+}
+RIGHT_P1={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
+]
+}
+LEFT_P1={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
+]
+}
+JUMP_P2={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+RIGHT_P2={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+LEFT_P2={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}

--- a/project.godot
+++ b/project.godot
@@ -51,3 +51,13 @@ LEFT_P2={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+REVERT_P1={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+]
+}
+REVERT_P2={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}


### PR DESCRIPTION
This pull request adds support for two-player controls and time travel functionality, allowing each player to have independent movement and time-revert actions. The main changes include updating the input mapping, player logic, and controller logic to handle per-player actions, as well as updating the scene to include a second player.

**Multi-player input and player logic:**

* Added per-player input actions (`LEFT_P1`, `RIGHT_P1`, `JUMP_P1`, etc.) and time-revert actions (`REVERT_P1`, `REVERT_P2`) to the input map in `project.godot`.
* Updated `player.gd` to use a new `player_number` property and dynamically assign input actions for movement and jumping based on the player's number. Logic for jumping and movement now uses these per-player actions.
* Modified the time-revert logic in `player.gd` so that each player only responds to their own revert signal, using the `player` argument in the signal.

**Time travel controller and signals:**

* Updated `time_travel_controller.gd` to check for both players' revert actions and emit the `revert_started` signal with the appropriate player number. The signal now includes a player argument. [[1]](diffhunk://#diff-a151786c54fa01141f1959b1100166d50057ffe985146d93b7b5bd1130dccad5R5-R9) [[2]](diffhunk://#diff-a151786c54fa01141f1959b1100166d50057ffe985146d93b7b5bd1130dccad5L17-R30)
* Changed the definition of the `revert_started` signal in `global.gd` to include a `player: int` argument.

**Scene and player instancing:**

* Updated `level.tscn` to instantiate two separate player nodes (`Player1` and `Player2`), each with their own position and `player_number` property. [[1]](diffhunk://#diff-71afb83aa61ded11312cf545f480730d0d81d9732d854f17e374a82dcf012b0fL9-R9) [[2]](diffhunk://#diff-71afb83aa61ded11312cf545f480730d0d81d9732d854f17e374a82dcf012b0fR31-R34)