### PR TITLE
add winning

### DIFF
--- a/entities/player/player.gd
+++ b/entities/player/player.gd
@@ -22,7 +22,7 @@ func _ready():
 	Global.revert_started.connect(start_reverting)
 	Global.revert_stopped.connect(stop_reverting)
 	add_to_group(Global.TIME_TRAVEL_GROUP)
-	
+	add_to_group(Global.PLAYER_GROUP)
 	
 
 

--- a/global.gd
+++ b/global.gd
@@ -7,8 +7,10 @@ const _max_history_length = (10 /  log_delay) * 1.2
 
 ## Gropus
 const TIME_TRAVEL_GROUP = "time_travelable"
+const PLAYER_GROUP = "player"
 
 ## Signals
 signal revert_started(player: int)
 signal revert_stopped()
 signal buttonChanged(groupId: int, active: bool)	
+signal game_won()

--- a/levels/level.tscn
+++ b/levels/level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://c7ejpm0cgaqea"]
+[gd_scene load_steps=12 format=3 uid="uid://c7ejpm0cgaqea"]
 
 [ext_resource type="PackedScene" uid="uid://bg8oq3w6fk3j3" path="res://entities/player/player.tscn" id="1_80vhd"]
 [ext_resource type="PackedScene" uid="uid://bn4dscbsrik6o" path="res://entities/enviroment/platform/platform.tscn" id="2_hjsbj"]
@@ -9,6 +9,8 @@
 [ext_resource type="Script" uid="uid://csb5qvgrujlvn" path="res://levels/pause_controller.gd" id="8_d5x7l"]
 [ext_resource type="PackedScene" uid="uid://0kx674o7igwo" path="res://visual/reverse_effect.tscn" id="9_rtcij"]
 [ext_resource type="PackedScene" uid="uid://d0oj0b2c0s4dd" path="res://controllers/time_travel_controller.tscn" id="9_ukwr8"]
+[ext_resource type="PackedScene" uid="uid://4brmlpdgi2ea" path="res://entities/enviroment/winning_door.tscn" id="10_ukwr8"]
+[ext_resource type="Script" uid="uid://bol7ttel1fahb" path="res://levels/scene_contoller.gd" id="11_pb8y7"]
 
 [node name="Node2D" type="Node2D"]
 
@@ -62,3 +64,10 @@ script = ExtResource("8_d5x7l")
 [node name="ReverseEffect" parent="." instance=ExtResource("9_rtcij")]
 
 [node name="TimeTravelController" parent="." instance=ExtResource("9_ukwr8")]
+
+[node name="WinningDoor" parent="." instance=ExtResource("10_ukwr8")]
+position = Vector2(333, 323)
+scale = Vector2(0.5, 0.5)
+
+[node name="SceneContoller" type="Node" parent="."]
+script = ExtResource("11_pb8y7")


### PR DESCRIPTION
This pull request introduces improvements to group management for the player entity and adds new features to the level, including the winning door and scene controller. The most important changes are grouped below:

**Player and Group Management:**

* Added the player entity to the new `PLAYER_GROUP` for more precise group-based operations (`player.gd`, `global.gd`). [[1]](diffhunk://#diff-831c94afbf605931cbfb3f9e6c4d1fd5f8007f1d0fa0428255e0a2bd78002053L25-R25) [[2]](diffhunk://#diff-b0c1321a0fd8d3477dd16190e408f6562cb8f64a57a936304df2bc5a06d810a4R10-R16)
* Defined the `PLAYER_GROUP` constant in `global.gd` to support this grouping.

**Level Additions:**

* Added the `WinningDoor` node to the level scene, including its position and scale, enabling win condition detection (`level.tscn`).
* Added the `SceneContoller` node with its associated script to the level for scene management functionality (`level.tscn`).
* Registered new external resources for the winning door and scene controller script in the level scene file (`level.tscn`).

These changes improve entity organization and introduce new gameplay and scene management features.